### PR TITLE
refine oauth2 handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,42 @@ npm install -g openshift-auth-proxy
 Usage: openshift-auth-proxy [options]
 
 Options:
-  --target                   Target to proxy to                                                               [required]
-  --target-ca                CA used to valid target server
-  --listen-port              Port to listen on                                                [required] [default: 3000]
-  --auth-mode                Auth mode                                 [choices: "oauth2", "bearer"] [default: "oauth2"]
-  --user-header              Header to set the user name on the proxied request      [required] [default: "REMOTE_USER"]
-  --session-secret           Secret for encrypted session cookies                      [required] [default: "generated"]
-  --session-duration         Duration for encrypted session cookies                        [required] [default: 3600000]
-  --session-active-duration  Active duration for encrypted session cookies                  [required] [default: 300000]
-  --session-ephemeral        Delete cookies on browser close                       [boolean] [required] [default: false]
-  --callback-url             oAuth callback URL                         [required] [default: "/auth/openshift/callback"]
-  --client-id                OAuth client ID                                                                  [required]
-  --client-secret            OAuth client secret                                                              [required]
-  --openshift-master         OpenShift master to authenticate against                                         [required]
-  --openshift-ca             CA certificate[s] to use                                                         [required]
-  --tls-cert                 Certificate file to use to listen for TLS                                        [required]
-  --tls-key                  Key file to use to listen for TLS                                                [required]
+  --listen-port              Port to listen on                                                           [default: 3000]
+  --server-cert              Certificate file to use to listen for TLS                   [default: "secret/server-cert"]
+  --server-key               Key file to use to listen for TLS                            [default: "secret/server-key"]
+  --server-tlsopts-file      File containing JSON for proxy TLS options              [default: "secret/server-tls.json"]
+  --backend                  Backend to proxy requests to once authenticated
+  --use-backend-host-header  Change the host header to the backend URL                        [boolean] [default: false]
+  --backend-ca               CA certificate file for validating the backend connection TLS (if needed)
+                                                                                          [default: "secret/backend-ca"]
+  --client-cert              Client certificate file for mutual TLS to the backend URL (if needed)
+                                                                                         [default: "secret/client-cert"]
+  --client-key               Client key file for mutual TLS to the backend URL (if needed)
+                                                                                          [default: "secret/client-key"]
+  --auth-mode                Proxy auth mode    [choices: "oauth2", "bearer", "mutual_tls", "dummy"] [default: "oauth2"]
+  --mutual-tls-ca            CA cert file to use for validating TLS client certs under "mutual_tls" auth method
+                                                                                           [default: "secret/mutual-ca"]
+  --session-secret           File containing secret for encrypted session cookies under "oauth2" method
+                                                                                      [default: "secret/session-secret"]
+  --session-duration         Duration for encrypted session cookies                                   [default: 3600000]
+  --session-active-duration  Active duration for encrypted session cookies                             [default: 300000]
+  --session-ephemeral        Delete cookies on browser close                                   [boolean] [default: true]
+  --callback-url             OAuth callback URL                                    [default: "/auth/openshift/callback"]
+  --logout-redirect          URL to send user to after they log out from OAuth session                    [default: "/"]
+  --oauth-id                 OAuth client ID
+  --oauth-secret             File containing OAuth client secret                        [default: "secret/oauth-secret"]
+  --public-master-url        Public master address for redirecting clients to
+  --master-url               Internal master address proxy will authenticate against for oauth/bearer
+                                                          [default: "https://kubernetes.default.svc.cluster.local:8443"]
+  --master-ca                CA certificate(s) file to validate connection to the master   [default: "secret/master-ca"]
+  --transform                Transform name(s) to apply to the request/response after authentication [choices: "
+                             user_header", "token_header", "none"]                              [default: "user_header"]
+  --user-header              Header for sending user name on the proxied request        [default: "X-Proxy-Remote-User"]
+  --trust-remote-user        Use the user-header from the proxied request (if set) as the user for the backend request.
+                                                                                                               [boolean]
+  --debug                    Show extra debug information at startup and during operations                     [boolean]
   --help                     Show help                                                                         [boolean]
 
-copyright 2015
+All of these parameters can be set via corresponding environment variables.
+
 ```

--- a/lib/authHandlers.js
+++ b/lib/authHandlers.js
@@ -4,6 +4,7 @@ var sessions       = require('client-sessions'),
     BearerStrategy = require('passport-http-bearer'),
     urljoin        = require('url-join'),
     request        = require('request'),
+    bodyParser     = require('body-parser'),
     config         = require('./config'),
     parseDuration  = require('parse-duration');
 
@@ -15,14 +16,26 @@ var sessions       = require('client-sessions'),
   //
   // set up for passport authentication if it will be needed
   //
-  var noSerialization = function(user, done) {
-    done(null, user);
+  var serializeUser = function(user, done) {
+    done(null, user.metadata.name + '\n' + user.token);
+  }
+  var deserializeUser = function(userString, done) {
+    var user = userString.split('\n');
+    done(null, {
+	         'token': user[1],
+		 'metadata': {
+		      'name': user[0]
+		 }
+               });
   }
 
+  //
+  // callback to check that a token is valid and pass on the user data
+  //
   var validateBearerToken = function(accessToken, refreshToken, profile, done) {
-    if (config.debug) console.log('in validateBearerToken: ', accessToken, refreshToken, profile);
+    config.debugLog('in validateBearerToken');
     if (!accessToken) {
-      if (config.debug) console.log('no access token, done.');
+      config.debugLog('no access token, done.');
       done();
     }
     var authOptions = {
@@ -33,17 +46,16 @@ var sessions       = require('client-sessions'),
     };
     var authReq = request.get(authOptions);
     authReq.on('response', function(authRes) {
-      if(config.debug) console.log('in authReq');
+      config.debugLog('in authReq');
       if (authRes.statusCode != 200) {
         done();
       } else {
         // collect response data, could be chunked
         var data = '';
-        authRes.on('data', function (chunk){
-          data += chunk;
-        });
+        authRes.on('data', function (chunk){ data += chunk });
         authRes.on('end',function(){
           var user = JSON.parse(data);
+          user.token = accessToken;
           done(null, user);
         });
       }
@@ -51,6 +63,7 @@ var sessions       = require('client-sessions'),
   };
 
   var setupOauth = function(app) {
+    // configure passport into the request w / oauth
     passport.use(new OAuth2Strategy({
         authorizationURL: urljoin(config['public-master-url'], '/oauth/authorize'),
         tokenURL: urljoin(config['master-url'], '/oauth/token'),
@@ -60,6 +73,7 @@ var sessions       = require('client-sessions'),
       },
       validateBearerToken
     ));
+    // we will record the user name + token in the session
     app.use(sessions({
       cookieName: 'openshift-auth-proxy-session',
       requestKey: 'session',
@@ -73,9 +87,7 @@ var sessions       = require('client-sessions'),
     app.use(passport.initialize());
     app.use(passport.session());
     app.get(config['callback-url'], function(req, res) {
-      if(config['debug']) {
-        console.log('in validateBearerToken for req path ' + req.path);
-      }
+      config.debugLog('in callback handler for req path %s', req.path);
       var returnTo = req.session.returnTo;
       passport.authenticate(config['auth-mode'])(req, res, function() {
         res.redirect(returnTo || '/');
@@ -83,18 +95,57 @@ var sessions       = require('client-sessions'),
     });
   }
 
+  var setupBearer = function(path, app) {
+    if (app == null) { app = path; path = null }
+    var bearer = new BearerStrategy(
+		    function(token, done) {
+		      validateBearerToken(token, null, null, done)
+		    }
+		 );
+    config.debugLog('in setupBearer');
+    passport.use(bearer);
+    if (path) app.use(path, passport.initialize());
+    else      app.use(passport.initialize());
+    passport.serializeUser(serializeUser);
+    passport.deserializeUser(deserializeUser);
+  }
+
+  var setupTokenRedirect = function(path, app) {
+    app.use(path, function(req, res, next) {
+      var target;
+      if (req.query) target = req.query.redirect;
+      if (req.body)  target = req.body.redirect || target;
+      if (target != null && target.indexOf("/") === 0)
+        res.redirect(target);
+      else
+        res.status(400).end('require "redirect" parameter beginning with "/"');
+    });
+  }
+
+  var handleLogout = function(req, res, next) {
+    req.logout();
+    res.redirect(config.logoutRedirect || "/");
+  };
+
   var useSession = false;
   var ensureAuthenticated = function(req, res, next) {
-    if (config.debug) console.log('in passport.ensureAuthenticated for req path ' + req.path);
+    config.debugLog('in passport.ensureAuthenticated for req path ' + req.path);
     if (req.isAuthenticated()) {
-      if (config.debug) { console.log('authenticated, moving on.')}
+      config.debugLog('authenticated by request session.');
       return next();
     }
-    if (config.debug) { console.log('not authenticated.')}
+    config.debugLog('not authenticated by request session.');
     if (useSession) {
       req.session.returnTo = req.path;
     }
-    passport.authenticate(config['auth-mode'], {session: useSession})(req, res, next);
+    switch(config['auth-mode']) {
+      case 'oauth2':
+        passport.authenticate(['bearer', 'oauth2'], {session: useSession})(req, res, next);
+	break;
+      case 'bearer':
+        passport.authenticate('bearer', {session: useSession})(req, res, next);
+	break;
+    }
   }
 
   //
@@ -104,17 +155,16 @@ var sessions       = require('client-sessions'),
     switch(config['auth-mode']) {
       case 'oauth2':
         useSession = true;
+        setupBearer(app);
         setupOauth(app);
-        // NO break, should implement bearer too
+	app.use("/auth/logout", handleLogout);
+        app.use("/auth/token", bodyParser.urlencoded({ extended: true })); // required to auth with POST params
+        app.use(ensureAuthenticated);
+        setupTokenRedirect("/auth/token", app);
+	break;
       case 'bearer':
-        passport.use(new BearerStrategy(
-          function(token, done) {
-            validateBearerToken(token, null, null, done);
-          }
-        ));
-        app.use(passport.initialize());
-        passport.serializeUser(noSerialization);
-        passport.deserializeUser(noSerialization);
+        setupBearer(app);
+        app.use(ensureAuthenticated);
         break;
       case 'mutual_tls':
         if (!files.mutualTlsCa) {
@@ -123,35 +173,38 @@ var sessions       = require('client-sessions'),
         files.serverTLS['ca'] = files.mutualTlsCa;
         files.serverTLS['requestCert'] = true;
         files.serverTLS['rejectUnauthorized'] = true;
-        ensureAuthenticated = function(req, res, next) {
-          if (config.debug) console.log('in mutual_tls.ensureAuthenticated for req path ' + req.path);
-          if (config.debug) console.log('client cert is: ', req.connection.getPeerCertificate());
+        app.use(function(req, res, next) {
+          config.debugLog('in mutual_tls.ensureAuthenticated for req path ' + req.path);
+          config.debugLog('client cert is: ', req.connection.getPeerCertificate());
           var userName = req.connection.getPeerCertificate().subject['CN'];
           req.user = { metadata: { name: userName }};
           return next();
-        };
+        });
         break;
       case 'dummy':
-        ensureAuthenticated = function(req, res, next) {
-          if (config.debug) console.log('in dummy.ensureAuthenticated for req path ' + req.path);
+        app.use(function(req, res, next) {
+          config.debugLog('in dummy.ensureAuthenticated for req path ' + req.path);
           req.user = { metadata: { name: 'dummy'}};
           return next();
-        };
+        });
+        break;
+      case 'none':
+        app.use(function(req, res, next) { return next() });
         break;
     };
-    app.use(ensureAuthenticated);
   }
 
   var userForRequest = function (req) {
-    var userName = req.user.metadata.name;
-    if (config.debug) console.log('request user is "%s"', userName);
+    var user = { 'name': req.user.metadata.name};
+    if (req.user.token) user.token = req.user.token
+    config.debugLog('request user is: ', user.name);
     if (config['trust-remote-user']) {
       // Trust/forward the remote user header if given.
       var headerName = req.headers[config['user-header'].toLowerCase()];
-      if (config.debug) console.log('header user is "%s"', headerName);
-      if (headerName) userName = headerName;
+      config.debugLog('header user is "%s"', headerName);
+      if (headerName) user.name = headerName;
     }
-    return userName;
+    return user;
   }
 
 module.exports = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -58,6 +58,9 @@ var config = require('yargs')
     }, 'callback-url': {
       describe: 'OAuth callback URL',
       default: process.env.OAP_CALLBACK_URL || '/auth/openshift/callback'
+    }, 'logout-redirect': {
+      describe: 'URL to send user to after they log out from OAuth session',
+      default: process.env.OAP_LOGOUT_REDIRECT || '/'
     }, 'oauth-id': {
       describe: 'OAuth client ID',
       default: process.env.OAP_OAUTH_ID
@@ -75,8 +78,8 @@ var config = require('yargs')
       default: process.env.OAP_MASTER_CA_FILE || 'secret/master-ca'
     }, 'transform': {
       // note: would like to be able to specify multiple in env var, but yargs.choices() does not validate input as comma-separated array
-      describe: 'Transform name(s) to apply to the request/response after authentication [choices: "user_header", "kibana_es", "none"]',
-      default: process.env.OAP_TRANSFORM || 'user_header'
+      describe: 'Transform name(s) to apply to the request/response after authentication [choices: "user_header", "token_header", "none"]',
+      default: process.env.OAP_TRANSFORM || 'user_header,token_header'
     }, 'user-header': {
       describe: 'Header for sending user name on the proxied request',
       default: process.env.OAP_REMOTE_USER_HEADER || 'X-Proxy-Remote-User'
@@ -84,9 +87,6 @@ var config = require('yargs')
       describe: 'Use the user-header from the proxied request (if set) as the user for the backend request.',
       type: 'boolean',
       default: process.env.OAP_TRUST_REMOTE_USER
-    }, 'kibana-index': {
-      describe: 'Name of index that Kibana wants to use for its data',
-      default: process.env.OAP_KIBANA_INDEX || '.kibana'
     }, debug: {
       describe: 'Show extra debug information at startup and during operations',
       type: 'boolean',
@@ -94,7 +94,7 @@ var config = require('yargs')
     }
   })
   .check(function(args) {
-    // yargs#demand doesn't work if we also provide a default, so check for missing/invalid args here
+    // yargs#demand doesn't complain on empty env var default; check for missing/invalid args here
     var errors = [];
     ['backend', 'server-cert', 'server-key', 'server-tlsopts-file', 'mutual-tls-ca'].forEach( function(val) {
       if(args[val] == null || args[val].length === 0) {
@@ -115,17 +115,22 @@ var config = require('yargs')
         }
       });
     }
-    if (args['auth-mode'] === 'mutual_tls' && (args['mutual-tls-ca'] == null || args['mutual-tls-ca'].length === 0))
-      errors.push('No value specified for "mutual_tls" parameter "mutual-tls-ca"');
+    if (args['auth-mode'] === 'mutual_tls' &&
+       (args['mutual-tls-ca'] == null || args['mutual-tls-ca'].length === 0))
+         errors.push('No value specified for "mutual_tls" parameter "mutual-tls-ca"');
     if (args['client-key'] && !args['client-cert'])
       errors.push('Specified client-key without client-cert');
     if (args['client-cert'] && !args['client-key'])
       errors.push('Specified client-cert without client-key');
-    if (isNaN(parseFloat(args['listen-port'])) || args['listen-port'] < 1) errors.push('Invalid listen-port specified');
-    (typeof(args.transform) === 'string' ? args.transform.split(',') : args.transform).forEach(function(transform) {
-      if (['user_header', 'forward_user', 'kibana_es', 'none'].indexOf(transform) === -1)
-        errors.push('Unknown transform specified: ' + transform);
-    });
+    if (isNaN(parseFloat(args['listen-port'])) || args['listen-port'] < 1)
+      errors.push('Invalid listen-port specified');
+    (typeof(args.transform) === 'string'
+      ? args.transform.split(',')
+      : args.transform).
+	forEach(function(transform) {
+          if (['user_header', 'token_header', 'none'].indexOf(transform) === -1)
+            errors.push('Unknown transform specified: ' + transform);
+        });
     // Now report errors if present.
     if (errors.length > 0) throw('ERROR IN PARAMETERS:\n' + errors.join('\n'));
     return true
@@ -134,14 +139,21 @@ var config = require('yargs')
   .epilog('All of these parameters can be set via corresponding environment variables.')
   .argv;
 
+// provide handy method for a debug log.
+config.debugLog = function() {
+  if (this.debug) console.log.apply(console, arguments)
+}
+
 //
 // read in all the files with secrets, keys, certs
 //
 var files = {};
 switch (config['auth-mode']) {
   case 'oauth2':
-    files.oauthSecret = fs.readFileSync(config['oauth-secret'], 'utf8').replace(/(\n|\r)/gm,'');
-    try {
+    // look for an oauth secret -- crash if not there
+    files.oauthSecret = fs.readFileSync(config['oauth-secret'], 'utf8').
+	                   replace(/(\n|\r)/gm,''); // newlines can mismatch secret
+    try { // ok if missing, we will generate
       files.sessionSecret = fs.readFileSync(config['session-secret'], 'utf8');
     } catch(err) {
       console.error('error reading session secret: %s', JSON.stringify(e));
@@ -151,7 +163,7 @@ switch (config['auth-mode']) {
         files.sessionSecret = require('base64url')(require('crypto').randomBytes(256)).substring(0, 256);
       }
     };
-    // don't break
+    // don't break, do both.
   case 'bearer': // and oauth2 as well:
     // ensure we validate connections to master w/ master CA.
     // technically this might not be required, but passport fails
@@ -168,9 +180,13 @@ switch (config['auth-mode']) {
     }
     break;
 };
-try { // optional TLS overrides (ciphersuite etc)
+
+//
+// optional TLS overrides (ciphersuite etc)
+//
+try {
   files.serverTLS = fs.readFileSync(config['server-tlsopts-file'], 'utf8');
-  if (config.debug) console.log('Read TLS opts from %s: %s', config['server-tlsopts-file'], files.serverTLS);
+  config.debugLog('Read TLS opts from %s: %s', config['server-tlsopts-file'], files.serverTLS);
   files.serverTLS = eval(files.serverTLS);
   if (files.serverTLS == null || ! typeof files.serverTLS === 'object') {
     throw('TLS opts file did not evaluate to an object');
@@ -181,11 +197,12 @@ try { // optional TLS overrides (ciphersuite etc)
 } finally {
   files.serverTLS['key'] = fs.readFileSync(config['server-key'], 'utf8');
   files.serverTLS['cert'] = fs.readFileSync(config['server-cert'], 'utf8');
-  if (config.debug) {
-    console.log('in finally, serverTLS is:');
-    console.log(files.serverTLS);
-  }
-};
+  config.debugLog('in finally, serverTLS is:', files.serverTLS);
+}
+
+//
+// read provided CA/client cert for secured backend connection
+//
 if ( config['backend'].indexOf('https:') === 0) {
   var backendAgentOpts = {};
   if (config['backend-ca']) backendAgentOpts['ca'] = fs.readFileSync(config['backend-ca'], 'utf8');
@@ -193,6 +210,10 @@ if ( config['backend'].indexOf('https:') === 0) {
   if (config['client-cert']) backendAgentOpts['cert'] = fs.readFileSync(config['client-cert'], 'utf8');
   config.backendAgent = new https.Agent(backendAgentOpts);
 }
+
+//
+// Display what we got, for debug purposes
+//
 if(config.debug) {
   console.log('config values passed in:');
   var arg;
@@ -204,9 +225,11 @@ if(config.debug) {
   })
 }
 
+// Some universal config values:
+//
 // where to get OpenShift user information for current auth
 config.openshiftUserUrl = urljoin(config['master-url'], '/oapi/v1/users/~');
-// make transforms an array
+// make sure transforms is an array
 config.transforms = typeof(config.transform) === 'string' ? config.transform.split(',') : config.transform;
 // hang the files on the config
 config.files = files;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -14,14 +14,21 @@ module.exports = {
     // Implement the configured proxy request transform(s)
     //
     var proxyTransformer = function (proxyReq, req, res, options) {
-      if (config.debug) console.log('in proxyTransformer content-length is', req.headers['content-length']);
+      config.debugLog('in proxyTransformer content-length is', req.headers['content-length']);
       config.transforms.forEach(function (name){
         switch (name) {
           case 'user_header':
-            var userName = userForRequest(req);
-            if (config.debug) console.log('setting %s header to "%s"', config['user-header'], userName);
+            var userName = userForRequest(req).name;
+            config.debugLog('setting %s header to "%s"', config['user-header'], userName);
             proxyReq.setHeader(config['user-header'], userName);
-    	break;
+            break;
+          case 'token_header':
+            var token = userForRequest(req).token;
+	    if (token) {
+              config.debugLog('setting Authorization header');
+              proxyReq.setHeader('Authorization', 'Bearer ' + token);
+	    }
+            break;
         }
       });
     }

--- a/openshift-auth-proxy.js
+++ b/openshift-auth-proxy.js
@@ -18,6 +18,8 @@ authHandlers.setupAuthHandler(app);
 proxy.setupProxy(app, authHandlers.userForRequest);
 
 // Create the server feeding requests to our express app
-console.log('Starting up the proxy with auth mode "%s" and proxy transform "%s".', config['auth-mode'], config.transforms.join() );
-https.createServer(config.files.serverTLS, app).listen(config['listen-port']);
+console.log('Starting up the proxy with auth mode "%s" and proxy transform "%s".',
+		config['auth-mode'], config.transforms.join() );
+https.createServer(config.files.serverTLS, app).
+      listen(config['listen-port']);
 


### PR DESCRIPTION
These changes:

- make oauth2 use both bearer and oauth2 auth, first falling back to latter.
- put the token in the session so it can be passed on to ES consistently
- provide a location `/auth/token` where the console can POST the token and be redirected to the intended destination with token in session
- provide `/auth/logout` which removes the session