### PR TITLE
Adding secondary session sharing

### DIFF
--- a/lib/authHandlers.js
+++ b/lib/authHandlers.js
@@ -7,6 +7,9 @@ var sessions       = require('client-sessions'),
     bodyParser     = require('body-parser'),
     config         = require('./config'),
     parseDuration  = require('parse-duration');
+    LRU            = require('lru-cache');
+
+var secondaryUserSessionTokens = new LRU(config['user-token-cache-size']);
 
 //
 // ---------------------- passport auth --------------------------
@@ -149,6 +152,21 @@ var sessions       = require('client-sessions'),
     }
   }
 
+  var handleSSOSetup = function(req, res, next) {
+    config.debugLog('in handleSSOSetup for access_token %s and user_token %s ', req.query.access_token, req.query.user_token);
+    secondaryUserSessionTokens.set(req.query.user_token, req.query.access_token);
+    res.send('sso setup OK.');
+  }
+
+  var handleSSOLogin = function(req, res, next) {
+    config.debugLog('in handleSSOLogin for user_token %s ', req.query.user_token);
+    if (req.query.user_token) {
+      req.query.access_token = secondaryUserSessionTokens.get(req.query.user_token);
+      secondaryUserSessionTokens.del(req.query.user_token);
+    }
+    next();
+  }
+
   //
   // Implement the configured authentication method handler
   //
@@ -158,11 +176,14 @@ var sessions       = require('client-sessions'),
         useSession = true;
         setupBearer(app);
         setupOauth(app);
-	app.use("/auth/logout", handleLogout);
+        app.use("/auth/sso-setup", handleSSOSetup);
+        app.use("/auth/sso-login", handleSSOLogin);
+        app.use("/auth/logout", handleLogout);
         app.use("/auth/token", bodyParser.urlencoded({ extended: true })); // required to auth with POST params
         app.use(ensureAuthenticated);
         setupTokenRedirect("/auth/token", app);
-	break;
+        setupTokenRedirect("/auth/sso-login", app);
+        break;
       case 'bearer':
         setupBearer(app);
         app.use(ensureAuthenticated);

--- a/lib/config.js
+++ b/lib/config.js
@@ -91,7 +91,10 @@ var config = require('yargs')
       describe: 'Show extra debug information at startup and during operations',
       type: 'boolean',
       default: process.env.OAP_DEBUG
-    }
+    }, 'user-token-cache-size': {
+			describe: 'Determine the size of the cache for the user tokens',
+			default: parseInt(process.env.OAP_USER_TOKEN_CACHE_SIZE) || 10,
+		},
   })
   .check(function(args) {
     // yargs#demand doesn't complain on empty env var default; check for missing/invalid args here

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "passport-oauth2": "^1.1.2",
     "request": "^2.60.0",
     "url-join": "0.0.1",
-    "yargs": "^3.18.0"
+    "yargs": "^3.18.0",
+    "lru-cache": "^4.0.2"
   }
 }


### PR DESCRIPTION
Adding two endpoints "/auth/sso-setup" and "/auth/sso-login" to allow giving a 3rd the ability to authenticate without actually sharing the token with it.

@jimmidyson  @sosiouxme @simon3z