### PR TITLE
use node 4.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10.36
+FROM node:4.7.2
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-auth-proxy",
-  "version": "0.0.24",
+  "version": "0.1.0",
   "description": "Reverse proxy to authorize requests against OpenShift 3",
   "main": "openshift-auth-proxy.js",
   "bin": "./openshift-auth-proxy.js",

--- a/run.sh
+++ b/run.sh
@@ -42,4 +42,4 @@ cd "${APP_DIR}"
 echo "Using NODE_OPTIONS: '${NODE_OPTIONS}' Memory setting is in MB"
 echo "Running from directory: '$(pwd)'"
 
-exec node ${NODE_OPTIONS} /usr/local/bin/npm start
+exec node ${NODE_OPTIONS} openshift-auth-proxy.js


### PR DESCRIPTION
Bumped to use node 4.7.2 which is what is available downstream.  This will make our packaging lives easier