### PR TITLE
upgraded to node 4.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.7.2
+FROM node:4.8.3
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 


### PR DESCRIPTION
**Issue**
When Openshift CA is generated using another CA, is not possible to login into Kibana and the user is always being redirected to the login page.
This PR is trying to fix BZ https://bugzilla.redhat.com/show_bug.cgi?id=1465022

**How to reproduce it**
1. Configure inventory with custom CA.
2. Regenerate CA and Certificates using ansible
`ansible-playbook playbooks/byo/openshift-cluster/redeploy-openshift-ca.yml`
3. Regenerate Certificates using ansible
`ansible-playbook playbooks/byo/openshift-cluster/redeploy-certificates.yml`
4. Deploy logging using default values
5. Access Kibana page and try to login

**How to confirm it is resolved**
1. Clone the project
2. Build image to deploy it to the local registry
`docker build -t <registry_svc_ip>:5000/logging/openshift-auth-proxy:0.1.1 .`
3. Login using a valid account
`oc login -u admin -p xxxx https://openshift.example.com:8443`
4. Push built image to local registry
`docker push <registry_svc_ip>:5000/logging/openshift-auth-proxy:0.1.1`
5. Edit the deploymentConfig to use this image and a new build will take place
6. Login into Kibana

**Additional info**
Tests have confirmed that the login loop does not happen on nodejs 4.8.3 when using certificates generated from an intermediate CA.
Actually I have verified that the fix was introduced between 4.8.0 and 4.8.1