### PR TITLE
bug 1468987: kibana_proxy OOM

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,9 @@ DEFAULT_MIN="$((64 * BYTES_PER_MEG))" #This is a guess
 if echo "${OCP_AUTH_PROXY_MEMORY_LIMIT:-}" | grep -qE "^([[:digit:]]+)([GgMm])?i?$"; then
     num="$(echo "${OCP_AUTH_PROXY_MEMORY_LIMIT}" | grep -oE "^[[:digit:]]+")"
     unit="$(echo "${OCP_AUTH_PROXY_MEMORY_LIMIT}" | grep -oE "[GgMm]" || echo "")"
+    
+    #set max_old_space_size to half of memory limit to allow some heap for other V8 spaces
+    num=$((num/2))
 
     if [ "${unit}" = "G" ] || [ "${unit}" = "g" ]; then
         num="$((num * BYTES_PER_GIG))" # enables math to work out for odd Gi


### PR DESCRIPTION
We currently set the memory allocated to the kibana-proxy container to be the same as `max_old_space_size` for nodejs. But in V8, the heap consists of multiple spaces.

The old space has only memory ready to be GC and measuring the used heap by kibana-proxy code, there is at least additional 32MB needed in the code space when `max_old_space_size` peaks.

Increasing the default memory limit to 256MB in openshift-ansible repository and also changing the default calculation of `max_old_space_size` here to be only half of what the container receives to allow some memory for other heap spaces.

https://github.com/openshift/openshift-ansible/pull/4761