### PR TITLE
[WIP] use memcached server for user tokens

### DIFF
--- a/lib/authHandlers.js
+++ b/lib/authHandlers.js
@@ -7,9 +7,10 @@ var sessions       = require('client-sessions'),
     bodyParser     = require('body-parser'),
     config         = require('./config'),
     parseDuration  = require('parse-duration');
-    LRU            = require('lru-cache');
+    Memcached      = require('memcached');
 
-var secondaryUserSessionTokens = new LRU(config['user-token-cache-size']);
+var memcached_token_client = new Memcached(config['user-token-memcached-hostname'].concat(':', config['user-token-memcached-port']))
+// var secondaryUserSessionTokens = new LRU(config['user-token-cache-size']);
 
 //
 // ---------------------- passport auth --------------------------
@@ -154,17 +155,33 @@ var secondaryUserSessionTokens = new LRU(config['user-token-cache-size']);
 
   var handleSSOSetup = function(req, res, next) {
     config.debugLog('in handleSSOSetup for access_token %s and user_token %s ', req.query.access_token, req.query.user_token);
-    secondaryUserSessionTokens.set(req.query.user_token, req.query.access_token);
-    res.send('sso setup OK.');
+    memcached_token_client.set(req.query.user_token, req.query.access_token, 10, function(err, result){
+      if (err) {
+        config.debugLog('error while setting user token in memcached %v', err);
+        res.send('sso setup Failed - Can\'t access memecached');
+      } else {
+        res.send('sso setup OK.');
+      }
+      memcached_token_client.end();
+    });
   }
 
   var handleSSOLogin = function(req, res, next) {
     config.debugLog('in handleSSOLogin for user_token %s ', req.query.user_token);
     if (req.query.user_token) {
-      req.query.access_token = secondaryUserSessionTokens.get(req.query.user_token);
-      secondaryUserSessionTokens.del(req.query.user_token);
+      memcached_token_client.get(req.query.user_token, function(err, result){
+        if (err){
+          config.debugLog('error while getting user token in memcached %v', err);
+        } else {
+          req.query.access_token = result;
+          config.debugLog('Received access_token: %s', req.query.access_token);
+        }
+        memcached_token_client.end();
+        next();
+      });
+    } else {
+      next();
     }
-    next();
   }
 
   //

--- a/lib/authHandlers.js
+++ b/lib/authHandlers.js
@@ -7,10 +7,11 @@ var sessions       = require('client-sessions'),
     bodyParser     = require('body-parser'),
     config         = require('./config'),
     parseDuration  = require('parse-duration');
+    LRU            = require('lru-cache');
     Memcached      = require('memcached');
 
+var secondaryUserSessionTokens = new LRU(config['user-token-cache-size']);
 var memcached_token_client = new Memcached(config['user-token-memcached-hostname'].concat(':', config['user-token-memcached-port']))
-// var secondaryUserSessionTokens = new LRU(config['user-token-cache-size']);
 
 //
 // ---------------------- passport auth --------------------------
@@ -155,10 +156,11 @@ var memcached_token_client = new Memcached(config['user-token-memcached-hostname
 
   var handleSSOSetup = function(req, res, next) {
     config.debugLog('in handleSSOSetup for access_token %s and user_token %s ', req.query.access_token, req.query.user_token);
+    secondaryUserSessionTokens.set(req.query.user_token, req.query.access_token);
     memcached_token_client.set(req.query.user_token, req.query.access_token, 10, function(err, result){
       if (err) {
         config.debugLog('error while setting user token in memcached %v', err);
-        res.send('sso setup Failed - Can\'t access memecached');
+        res.send('sso setup Partially Failed - Can\'t access memecached');
       } else {
         res.send('sso setup OK.');
       }
@@ -169,16 +171,22 @@ var memcached_token_client = new Memcached(config['user-token-memcached-hostname
   var handleSSOLogin = function(req, res, next) {
     config.debugLog('in handleSSOLogin for user_token %s ', req.query.user_token);
     if (req.query.user_token) {
-      memcached_token_client.get(req.query.user_token, function(err, result){
-        if (err){
-          config.debugLog('error while getting user token in memcached %v', err);
-        } else {
-          req.query.access_token = result;
-          config.debugLog('Received access_token: %s', req.query.access_token);
-        }
-        memcached_token_client.end();
+      req.query.access_token = secondaryUserSessionTokens.get(req.query.user_token);
+      if (req.query.access_token) {
+        secondaryUserSessionTokens.del(req.query.user_token);
         next();
-      });
+      } else {
+        memcached_token_client.get(req.query.user_token, function(err, result){
+          if (err){
+            config.debugLog('error while getting user token in memcached %v', err);
+          } else {
+            req.query.access_token = result;
+            config.debugLog('Received access_token: %s', req.query.access_token);
+          }
+          memcached_token_client.end();
+          next();
+        });
+      }
     } else {
       next();
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -91,13 +91,16 @@ var config = require('yargs')
       describe: 'Show extra debug information at startup and during operations',
       type: 'boolean',
       default: process.env.OAP_DEBUG
+    }, 'user-token-cache-size': {
+      describe: 'Determine the size of the cache for the user tokens',
+      default: parseInt(process.env.OAP_USER_TOKEN_CACHE_SIZE) || 10,
     }, 'user-token-memcached-hostname': {
-			describe: 'Hostname of the memcached server for the user tokens',
-			default: process.env.OAP_USER_TOKEN_MEMCACHED_HOSTNAME || 'memecached'
-		}, 'user-token-memcached-port': {
-			describe: 'Port of the memcached server for the user tokens',
-			default: parseInt(process.env.OAP_USER_TOKEN_MEMCACHED_PORT) || '11211'
-		},
+      describe: 'Hostname of the memcached server for the user tokens',
+      default: process.env.OAP_USER_TOKEN_MEMCACHED_HOSTNAME || 'memecached'
+    }, 'user-token-memcached-port': {
+      describe: 'Port of the memcached server for the user tokens',
+      default: parseInt(process.env.OAP_USER_TOKEN_MEMCACHED_PORT) || '11211'
+    },
   })
   .check(function(args) {
     // yargs#demand doesn't complain on empty env var default; check for missing/invalid args here

--- a/lib/config.js
+++ b/lib/config.js
@@ -91,9 +91,12 @@ var config = require('yargs')
       describe: 'Show extra debug information at startup and during operations',
       type: 'boolean',
       default: process.env.OAP_DEBUG
-    }, 'user-token-cache-size': {
-			describe: 'Determine the size of the cache for the user tokens',
-			default: parseInt(process.env.OAP_USER_TOKEN_CACHE_SIZE) || 10,
+    }, 'user-token-memcached-hostname': {
+			describe: 'Hostname of the memcached server for the user tokens',
+			default: process.env.OAP_USER_TOKEN_MEMCACHED_HOSTNAME || 'memecached'
+		}, 'user-token-memcached-port': {
+			describe: 'Port of the memcached server for the user tokens',
+			default: parseInt(process.env.OAP_USER_TOKEN_MEMCACHED_PORT) || '11211'
 		},
   })
   .check(function(args) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "request": "^2.60.0",
     "url-join": "0.0.1",
     "yargs": "^3.18.0",
+    "lru-cache": "^4.0.2",
     "memcached": "2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "request": "^2.60.0",
     "url-join": "0.0.1",
     "yargs": "^3.18.0",
-    "lru-cache": "^4.0.2"
+    "memcached": "2.2.2"
   }
 }


### PR DESCRIPTION
This will use memcached to sync on the User/Access token paris between different replicas of openshift-auth-proxy to allow users to login from a different pod than the one that was used for SSO.

PR in openshift-ansible to add memcached to the stack: https://github.com/openshift/openshift-ansible/pull/4834