### PR TITLE
Update to a supported nodejs version

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,4 +1,4 @@
-FROM node:4.7.2
+FROM node:8
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 


### PR DESCRIPTION
Fixes #30 

I have the proxy now around two weeks in use and discovered no problems.
The build throws now a warning. I think node in version 4.7.2 is also affected, except that the warning is not thrown.
```
npm WARN notice [SECURITY] base64url has the following vulnerability: 1 moderate. Go here for more details: https://nodesecurity.io/advisories?search=base64url&version=1.0.6 
```

Take a look t supported node version: https://github.com/nodejs/Release